### PR TITLE
fix: command ID for axisinertia

### DIFF
--- a/OpenFFBSharp/Commands.cs
+++ b/OpenFFBSharp/Commands.cs
@@ -962,7 +962,7 @@ namespace OpenFFBoard
             #endregion
 
             #region axisinertia
-            private readonly BoardCommand<long> _axisinertia = new BoardCommand<long>("axisinertia", 0xF, "Axis Inertia. Independent inertia effect. 255=100%", CmdTypes.Get | CmdTypes.Set);
+            private readonly BoardCommand<long> _axisinertia = new BoardCommand<long>("axisinertia", 0x17, "Axis Inertia. Independent inertia effect. 255=100%", CmdTypes.Get | CmdTypes.Set);
 
             /// <summary>
             /// Axis Inertia configured position


### PR DESCRIPTION
The CMD ID is different, it's somehow 0x17 instead of 0xF that is related to something else: https://github.com/Ultrawipf/OpenFFBoard/wiki/Commands